### PR TITLE
Fixing Typos

### DIFF
--- a/notebooks/lectures/CAPM_and_Arbitrage_Pricing_Theory/notebook.ipynb
+++ b/notebooks/lectures/CAPM_and_Arbitrage_Pricing_Theory/notebook.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "---\n",
     "\n",
-    "The Capital Asset Pricing Model (CAPM) is a classic measure of the cost of capital. It is used often in finance to evaluate the price of assets and to assess the impact of the risk premium from the market at large. In this lecture, we discuss the CAPM the more general Arbitrage Pricing Theory (APT) to form a basis for evaluating the risk associated with various factors."
+    "The Capital Asset Pricing Model (CAPM) is a classic measure of the cost of capital. It is used often in finance to evaluate the price of assets and to assess the impact of the risk premium from the market at large. In this lecture, we discuss the CAPM and the more general Arbitrage Pricing Theory (APT) to form a basis for evaluating the risk associated with various factors."
    ]
   },
   {


### PR DESCRIPTION
Put an "and" between "the CAPM" and "the more general".